### PR TITLE
Add duckduckgo search, set default search to duckduckgo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "langchain-community>=0.3.9",
     "tavily-python>=0.5.0",
     "langchain-ollama>=0.2.1",
+    "duckduckgo-search>=7.3.0",
+    "beautifulsoup4>=4.13.3",
 ]
 
 [project.optional-dependencies]

--- a/src/assistant/configuration.py
+++ b/src/assistant/configuration.py
@@ -10,13 +10,15 @@ from enum import Enum
 class SearchAPI(Enum):
     PERPLEXITY = "perplexity"
     TAVILY = "tavily"
+    DUCKDUCKGO = "duckduckgo"
 
 @dataclass(kw_only=True)
 class Configuration:
     """The configurable fields for the research assistant."""
     max_web_research_loops: int = 3
     local_llm: str = "llama3.2"
-    search_api: SearchAPI = SearchAPI.TAVILY  # Default to TAVILY
+    search_api: SearchAPI = SearchAPI.DUCKDUCKGO  # Default to DUCDUCKGO
+    fetch_full_page: bool = False  # Default to False
 
     @classmethod
     def from_runnable_config(

--- a/src/assistant/graph.py
+++ b/src/assistant/graph.py
@@ -8,7 +8,7 @@ from langchain_ollama import ChatOllama
 from langgraph.graph import START, END, StateGraph
 
 from assistant.configuration import Configuration, SearchAPI
-from assistant.utils import deduplicate_and_format_sources, tavily_search, format_sources, perplexity_search
+from assistant.utils import deduplicate_and_format_sources, tavily_search, format_sources, perplexity_search, duckduckgo_search
 from assistant.state import SummaryState, SummaryStateInput, SummaryStateOutput
 from assistant.prompts import query_writer_instructions, summarizer_instructions, reflection_instructions
 
@@ -51,6 +51,9 @@ def web_research(state: SummaryState, config: RunnableConfig):
     elif search_api == "perplexity":
         search_results = perplexity_search(state.search_query, state.research_loop_count)
         search_str = deduplicate_and_format_sources(search_results, max_tokens_per_source=1000, include_raw_content=False)
+    elif search_api == "duckduckgo":
+        search_results = duckduckgo_search(state.search_query, max_results=3, fetch_full_page=configurable.fetch_full_page)
+        search_str = deduplicate_and_format_sources(search_results, max_tokens_per_source=1000, include_raw_content=True)
     else:
         raise ValueError(f"Unsupported search API: {configurable.search_api}")
         


### PR DESCRIPTION
Added duckduckgo search as an alternative to Tavily and Perplexity, also set it to default as it is free and doesn't require an API Key

Also, added a new "Fetch Full Page" as an option to fetch the full page using urllib.request and BeautifulSoup to extract the content (This was added because duckduckgo search doesn't return the raw page)