### PR TITLE
convert max_web_research_loops to int to make sure comparison works

### DIFF
--- a/src/assistant/graph.py
+++ b/src/assistant/graph.py
@@ -136,7 +136,7 @@ def route_research(state: SummaryState, config: RunnableConfig) -> Literal["fina
     """ Route the research based on the follow-up query """
 
     configurable = Configuration.from_runnable_config(config)
-    if state.research_loop_count <= configurable.max_web_research_loops:
+    if state.research_loop_count <= int(configurable.max_web_research_loops):
         return "web_research"
     else:
         return "finalize_summary"


### PR DESCRIPTION
This PR fixes a bug introduced by my previous PR and the getting the max_web_research_loops from the environment variable. I'm not sure why it is a string value when doing the `if state.research_loop_count <= int(configurable.max_web_research_loops):` compare, I fixed it with just another `int()` around it.

Sorry for that!