### PR TITLE
Update .env.example for setting the default value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-OLLAMA_BASE_URL=                # the endpoint of the Ollama service, defaults to http://localhost:11434 if not set
-OLLAMA_MODEL=                   # the name of the model to use, defaults to 'llama3.2' if not set
+OLLAMA_BASE_URL=http://localhost:11434                # the endpoint of the Ollama service, defaults to http://localhost:11434 if not set
+OLLAMA_MODEL=deepseek-r1:1.5b                  # the name of the model to use, defaults to 'llama3.2' if not set
 
 # Which search service to use, either 'duckduckgo' or 'tavily' or 'perplexity'
-SEARCH_API=
+SEARCH_API='duckduckgo'
 # Web Search API Keys (choose one or both)
 TAVILY_API_KEY=tvly-xxxxx      # Get your key at https://tavily.com
 PERPLEXITY_API_KEY=pplx-xxxxx  # Get your key at https://www.perplexity.ai
 
-MAX_WEB_RESEARCH_LOOPS=
-FETCH_FULL_PAGE=
+MAX_WEB_RESEARCH_LOOPS=3
+FETCH_FULL_PAGE=True


### PR DESCRIPTION
Updated default values in the .env.example file to prevent `from_runnable_config` from pulling null values. This ensures a smoother setup experience for newcomers and avoids common initialization issues.