### PR TITLE
fix: honor max_web_research_loops boundary

### DIFF
--- a/src/ollama_deep_researcher/graph.py
+++ b/src/ollama_deep_researcher/graph.py
@@ -435,7 +435,7 @@ def route_research(
     """
 
     configurable = Configuration.from_runnable_config(config)
-    if state.research_loop_count <= configurable.max_web_research_loops:
+    if state.research_loop_count < configurable.max_web_research_loops:
         return "web_research"
     else:
         return "finalize_summary"

--- a/tests/test_route_research.py
+++ b/tests/test_route_research.py
@@ -1,0 +1,16 @@
+from ollama_deep_researcher.graph import route_research
+from ollama_deep_researcher.state import SummaryState
+
+
+def test_route_research_continues_before_max_loops():
+    state = SummaryState(research_topic="langgraph", research_loop_count=2)
+    config = {"configurable": {"max_web_research_loops": 3}}
+
+    assert route_research(state, config) == "web_research"
+
+
+def test_route_research_finalizes_at_max_loops():
+    state = SummaryState(research_topic="langgraph", research_loop_count=3)
+    config = {"configurable": {"max_web_research_loops": 3}}
+
+    assert route_research(state, config) == "finalize_summary"


### PR DESCRIPTION
## What changed
- Fixed an off-by-one condition in `route_research` so the graph now stops web-research iterations when `research_loop_count` reaches `max_web_research_loops`.
- Added regression tests in `tests/test_route_research.py` to verify:
  - it continues research when loop count is below the configured max;
  - it finalizes immediately when loop count equals the configured max.

## Why
- The previous condition used `<=`, which triggered one extra `web_research` cycle at the max boundary.
- That causes unnecessary search + LLM work, increasing latency and token/API cost.

## Insight / Why this matters
- **Root cause:** a boundary check (`<=`) in the router allowed one more iteration than intended.
- **Why easy to miss:** behavior only diverges exactly at the loop limit; normal runs still “work,” just with hidden extra cost.
- **Practical impact:** predictable iteration control, lower cost/latency, and fewer unnecessary external search calls.
- **Tradeoff/risk:** low risk and rollback-safe; scoped to one routing branch with explicit tests for both sides of the boundary.

## Testing
- ✅ `.venv/bin/pytest -q`
  - `2 passed`
