### PR TITLE
Add multi-agent collaborative research example with AG2

### DIFF
--- a/examples/ag2_multiagent_research.py
+++ b/examples/ag2_multiagent_research.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Multi-Agent Collaborative Research with AG2 + Local Deep Researcher.
+
+Demonstrates how AG2 agents can use Local Deep Researcher's LangGraph
+workflow as registered tools to perform multi-perspective research.
+Three agents collaborate:
+
+- Fact Checker: runs quick (1-iteration) searches on sub-questions
+- Deep Researcher: runs deeper (3-iteration) searches on key aspects
+- Report Writer: synthesizes all findings into a final summary
+
+Each tool wraps the compiled LangGraph research graph from
+``ollama_deep_researcher.graph`` with different iteration depths.
+
+Requirements:
+    pip install "ag2[openai]>=0.11.4,<1.0"
+    pip install -e .  # install local-deep-researcher
+
+    # Ollama must be running with a model pulled (default: llama3.2)
+    ollama pull llama3.2
+
+Usage:
+    # Set your OpenAI API key (used by AG2 agents for orchestration)
+    export OPENAI_API_KEY=your-key
+
+    # Run the example
+    python examples/ag2_multiagent_research.py
+
+Note:
+    The OPENAI_API_KEY is used only by AG2 for agent-to-agent orchestration.
+    Local Deep Researcher uses Ollama (local LLM) and DuckDuckGo (no API key)
+    by default. Configure via environment variables — see .env.example.
+"""
+
+import json
+import os
+from typing import Annotated
+
+from autogen import (
+    AssistantAgent,
+    GroupChat,
+    GroupChatManager,
+    LLMConfig,
+    UserProxyAgent,
+)
+
+from ollama_deep_researcher.graph import graph
+
+
+def _run_research(topic: str, max_loops: int = 3) -> dict:
+    """Invoke the LangGraph research workflow and return results.
+
+    Args:
+        topic: The research question or topic.
+        max_loops: Number of search-summarize-reflect iterations.
+
+    Returns:
+        Dictionary with the research summary and sources.
+    """
+    config = {
+        "configurable": {
+            "max_web_research_loops": max_loops,
+        }
+    }
+    result = graph.invoke({"research_topic": topic}, config=config)
+    return {
+        "topic": topic,
+        "summary": result.get("running_summary", ""),
+        "iterations": max_loops,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Tool functions — wrap the LangGraph research graph for AG2 agents
+# --------------------------------------------------------------------------- #
+def quick_research(
+    query: Annotated[str, "Research question to get a quick overview for"],
+) -> str:
+    """Run a quick 1-iteration research pass using Local Deep Researcher.
+
+    Good for fact-checking, getting overviews, or answering sub-questions.
+    Uses DuckDuckGo search with a single search-summarize cycle.
+    """
+    result = _run_research(query, max_loops=1)
+    return json.dumps(result, indent=2)
+
+
+def deep_research(
+    query: Annotated[str, "Research question for in-depth iterative analysis"],
+    iterations: Annotated[int, "Number of research iterations (1-5)"] = 3,
+) -> str:
+    """Run deep iterative research using Local Deep Researcher.
+
+    Performs multiple search-summarize-reflect cycles, each refining the
+    query based on knowledge gaps found in previous results. Returns a
+    detailed summary with source citations.
+    """
+    result = _run_research(query, max_loops=min(max(iterations, 1), 5))
+    return json.dumps(result, indent=2)
+
+
+# --------------------------------------------------------------------------- #
+# AG2 LLM configuration for agent orchestration
+# --------------------------------------------------------------------------- #
+llm_config = LLMConfig(
+    {
+        "model": "gpt-4o-mini",
+        "api_key": os.getenv("OPENAI_API_KEY"),
+        "api_type": "openai",
+    }
+)
+
+# --------------------------------------------------------------------------- #
+# AG2 agents
+# --------------------------------------------------------------------------- #
+fact_checker = AssistantAgent(
+    name="Fact_Checker",
+    system_message=(
+        "You are a fact checker. Your job is to gather quick overviews on "
+        "specific sub-questions related to the main research topic. "
+        "Use quick_research to check individual claims or get overviews "
+        "of specific aspects. Break the main question into 2-3 focused "
+        "sub-questions and research each one. Present your findings clearly."
+    ),
+    llm_config=llm_config,
+)
+
+deep_researcher = AssistantAgent(
+    name="Deep_Researcher",
+    system_message=(
+        "You are a deep research analyst. After the Fact Checker has gathered "
+        "initial findings, use deep_research to perform in-depth iterative "
+        "analysis on the most important aspects. Focus on areas where the "
+        "quick overviews revealed knowledge gaps or conflicting information. "
+        "Use 3 iterations for thorough results."
+    ),
+    llm_config=llm_config,
+)
+
+report_writer = AssistantAgent(
+    name="Report_Writer",
+    system_message=(
+        "You are a research report writer. After the Fact Checker and Deep "
+        "Researcher have gathered findings, synthesize everything into a "
+        "clear, well-structured summary with key findings, supporting "
+        "evidence, and source citations. End your message with TERMINATE."
+    ),
+    llm_config=llm_config,
+)
+
+executor = UserProxyAgent(
+    name="Executor",
+    human_input_mode="NEVER",
+    max_consecutive_auto_reply=10,
+    code_execution_config=False,
+)
+
+# Register tools — all agents can request them, executor runs them
+for tool_fn, description in [
+    (quick_research, "Run a quick 1-iteration research pass on a question"),
+    (deep_research, "Run deep multi-iteration research on a question"),
+]:
+    executor.register_for_execution()(tool_fn)
+    fact_checker.register_for_llm(description=description)(tool_fn)
+    deep_researcher.register_for_llm(description=description)(tool_fn)
+    report_writer.register_for_llm(description=description)(tool_fn)
+
+
+# --------------------------------------------------------------------------- #
+# Run the multi-agent research pipeline
+# --------------------------------------------------------------------------- #
+def main():
+    """Run a collaborative multi-agent research session."""
+    group_chat = GroupChat(
+        agents=[executor, fact_checker, deep_researcher, report_writer],
+        messages=[],
+        max_round=15,
+        speaker_selection_method="auto",
+    )
+
+    manager = GroupChatManager(
+        groupchat=group_chat,
+        llm_config=llm_config,
+    )
+
+    research_topic = (
+        "What are the current approaches to making large language models "
+        "more energy efficient, and what are the most promising techniques "
+        "for reducing their computational costs?"
+    )
+
+    print(f"Starting multi-agent research on:\n{research_topic}\n")  # noqa: T201
+    print("Pipeline: Fact Checker -> Deep Researcher -> Report Writer\n")  # noqa: T201
+
+    executor.run(manager, message=research_topic).process()
+
+    print("\n" + "=" * 60)  # noqa: T201
+    print("Research complete!")  # noqa: T201
+    print("=" * 60)  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ag2_multiagent_research.py
+++ b/examples/ag2_multiagent_research.py
@@ -34,9 +34,15 @@ Note:
 
 import json
 import os
+from pathlib import Path
 from typing import Annotated
 
-from autogen import (
+from dotenv import load_dotenv
+
+# Load .env from project root so OPENAI_API_KEY is available
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from autogen import (  # noqa: E402
     AssistantAgent,
     GroupChat,
     GroupChatManager,
@@ -44,7 +50,7 @@ from autogen import (
     UserProxyAgent,
 )
 
-from ollama_deep_researcher.graph import graph
+from ollama_deep_researcher.graph import graph  # noqa: E402
 
 
 def _run_research(topic: str, max_loops: int = 3) -> dict:


### PR DESCRIPTION
## Summary

- Adds an example script showing how [AG2](https://ag2.ai) agents can use Local Deep Researcher's LangGraph workflow for collaborative, multi-perspective research
- Three AG2 agents (Fact Checker, Deep Researcher, Report Writer) coordinate through GroupChat, each calling LDR's research graph as registered tools
- Single `.py` file in `examples/`, no changes to existing code

## What it does

1. **Fact Checker** — uses `quick_research` (1-iteration) to gather fast overviews on sub-questions
2. **Deep Researcher** — uses `deep_research` (multi-iteration) for in-depth analysis on key aspects
3. **Report Writer** — synthesizes findings into a structured summary

Each tool wraps `ollama_deep_researcher.graph.invoke()` with different iteration depths. Agents coordinate via AG2's GroupChat with automatic speaker selection.

## Files

- `examples/ag2_multiagent_research.py` — single script, no changes to existing code

## Testing

- Script passes `ruff check` and `ruff format`
- Tested e2e with mocked Ollama + real OpenAI for AG2 orchestration
- Verified: tool registration, LangGraph invocation, full agent pipeline