### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
-# Which search service to use, either 'duckduckgo', 'tavily', 'perplexity', Searxng
+# Which search service to use, either 'duckduckgo', 'tavily', 'perplexity', 'searxng', or 'exa'
 SEARCH_API='duckduckgo'
 # For Searxng search, defaults to http://localhost:8888
 SEARXNG_URL=
 
-# Web Search API Keys (choose one or both)
+# Web Search API Keys (choose one or more)
 TAVILY_API_KEY=tvly-xxxxx      # Get your key at https://tavily.com
 PERPLEXITY_API_KEY=pplx-xxxxx  # Get your key at https://www.perplexity.ai
+EXA_API_KEY=                   # Get your key at https://exa.ai
 
 # LLM Configuration
 LLM_PROVIDER=lmstudio          # Options: ollama, lmstudio

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ LMSTUDIO_BASE_URL=http://localhost:1234/v1
 
 ### Selecting search tool
 
-By default, it will use [DuckDuckGo](https://duckduckgo.com/) for web search, which does not require an API key. But you can also use [SearXNG](https://docs.searxng.org/), [Tavily](https://tavily.com/) or [Perplexity](https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api) by adding their API keys to the environment file. Optionally, update the `.env` file with the following search tool configuration and API keys. If set, these values will take precedence over the defaults set in the `Configuration` class in `configuration.py`. 
+By default, it will use [DuckDuckGo](https://duckduckgo.com/) for web search, which does not require an API key. But you can also use [SearXNG](https://docs.searxng.org/), [Tavily](https://tavily.com/), [Perplexity](https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api), or [Exa](https://exa.ai/) by adding their API keys to the environment file. Optionally, update the `.env` file with the following search tool configuration and API keys. If set, these values will take precedence over the defaults set in the `Configuration` class in `configuration.py`. 
 ```shell
 SEARCH_API=xxx # the search API to use, such as `duckduckgo` (default)
 TAVILY_API_KEY=xxx # the tavily API key to use
 PERPLEXITY_API_KEY=xxx # the perplexity API key to use
+EXA_API_KEY=xxx # the Exa API key to use
 MAX_WEB_RESEARCH_LOOPS=xxx # the maximum number of research loop steps, defaults to `3`
 FETCH_FULL_PAGE=xxx # fetch the full page content (with `duckduckgo`), defaults to `false`
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "langgraph>=1.1.0",
     "langchain-community>=0.4.0",
     "tavily-python>=0.7.23",
+    "exa-py>=2.0.0",
     "langchain-ollama>=1.0.0",
     "duckduckgo-search>=7.3.0",
     "langchain-openai>=1.1.14",

--- a/src/ollama_deep_researcher/configuration.py
+++ b/src/ollama_deep_researcher/configuration.py
@@ -11,6 +11,7 @@ class SearchAPI(Enum):
     TAVILY = "tavily"
     DUCKDUCKGO = "duckduckgo"
     SEARXNG = "searxng"
+    EXA = "exa"
 
 
 class Configuration(BaseModel):
@@ -31,8 +32,12 @@ class Configuration(BaseModel):
         title="LLM Provider",
         description="Provider for the LLM (Ollama or LMStudio)",
     )
-    search_api: Literal["perplexity", "tavily", "duckduckgo", "searxng"] = Field(
-        default="duckduckgo", title="Search API", description="Web search API to use"
+    search_api: Literal["perplexity", "tavily", "duckduckgo", "searxng", "exa"] = (
+        Field(
+            default="duckduckgo",
+            title="Search API",
+            description="Web search API to use",
+        )
     )
     fetch_full_page: bool = Field(
         default=True,

--- a/src/ollama_deep_researcher/graph.py
+++ b/src/ollama_deep_researcher/graph.py
@@ -17,6 +17,7 @@ from ollama_deep_researcher.utils import (
     perplexity_search,
     duckduckgo_search,
     searxng_search,
+    exa_search,
     strip_thinking_tokens,
     get_config_value,
 )
@@ -243,6 +244,17 @@ def web_research(state: SummaryState, config: RunnableConfig):
         )
     elif search_api == "searxng":
         search_results = searxng_search(
+            state.search_query,
+            max_results=3,
+            fetch_full_page=configurable.fetch_full_page,
+        )
+        search_str = deduplicate_and_format_sources(
+            search_results,
+            max_tokens_per_source=MAX_TOKENS_PER_SOURCE,
+            fetch_full_page=configurable.fetch_full_page,
+        )
+    elif search_api == "exa":
+        search_results = exa_search(
             state.search_query,
             max_results=3,
             fetch_full_page=configurable.fetch_full_page,

--- a/src/ollama_deep_researcher/utils.py
+++ b/src/ollama_deep_researcher/utils.py
@@ -7,6 +7,7 @@ from markdownify import markdownify
 from langsmith import traceable
 from tavily import TavilyClient
 from duckduckgo_search import DDGS
+from exa_py import Exa
 
 from langchain_community.utilities import SearxSearchWrapper
 
@@ -381,6 +382,87 @@ def perplexity_search(
                 "url": citation,
                 "content": "See above for full content",
                 "raw_content": None,
+            }
+        )
+
+    return {"results": results}
+
+
+@traceable
+def exa_search(
+    query: str, max_results: int = 3, fetch_full_page: bool = False
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Search the web using the Exa API and return formatted results.
+
+    Uses the Exa Python SDK to perform AI-powered web searches with content
+    retrieval. Requires an EXA_API_KEY environment variable to be set.
+
+    Both highlights and text content are requested so the formatter can fall
+    back gracefully when one is missing for a given result.
+
+    Args:
+        query (str): The search query to execute
+        max_results (int, optional): Maximum number of results to return. Defaults to 3.
+        fetch_full_page (bool, optional): Whether to include full page text as raw_content.
+                                         When False, raw_content mirrors the snippet.
+                                         Defaults to False.
+
+    Returns:
+        Dict[str, List[Dict[str, Any]]]: Search response containing:
+            - results (list): List of search result dictionaries, each containing:
+                - title (str): Title of the search result
+                - url (str): URL of the search result
+                - content (str): Highlight or text excerpt from the page
+                - raw_content (str or None): Full page text when fetch_full_page is True,
+                                            otherwise mirrors content
+    """
+    exa = Exa(api_key=os.getenv("EXA_API_KEY"))
+    exa.headers["x-exa-integration"] = "local-deep-researcher"
+
+    contents: Dict[str, Any] = {
+        "highlights": {"num_sentences": 3, "highlights_per_url": 3},
+        "text": {"max_characters": 8000} if fetch_full_page else True,
+    }
+
+    response = exa.search_and_contents(
+        query,
+        num_results=max_results,
+        type="auto",
+        contents=contents,
+    )
+
+    results = []
+    for r in response.results:
+        title = getattr(r, "title", None) or ""
+        url = getattr(r, "url", "") or ""
+        text = getattr(r, "text", None) or ""
+        highlights = getattr(r, "highlights", None) or []
+        summary = getattr(r, "summary", None) or ""
+
+        # Cascade through highlights -> summary -> text for the snippet
+        if highlights:
+            content = "\n".join(highlights)
+        elif summary:
+            content = summary
+        else:
+            content = text
+
+        if fetch_full_page:
+            raw_content = text or content
+        else:
+            raw_content = content
+
+        if not all([url, title, content]):
+            print(f"Warning: Incomplete result from Exa: {url}")
+            continue
+
+        results.append(
+            {
+                "title": title,
+                "url": url,
+                "content": content,
+                "raw_content": raw_content,
             }
         )
 

--- a/tests/test_exa_search.py
+++ b/tests/test_exa_search.py
@@ -1,0 +1,174 @@
+"""Unit tests for the Exa search provider."""
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ollama_deep_researcher.utils import exa_search
+
+
+def _make_response(results):
+    return SimpleNamespace(results=results)
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_uses_highlights_when_present(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response(
+        [
+            SimpleNamespace(
+                title="Result A",
+                url="https://example.com/a",
+                text="full body text",
+                highlights=["first highlight", "second highlight"],
+                summary=None,
+            )
+        ]
+    )
+    mock_exa_cls.return_value = client
+
+    result = exa_search("test query", max_results=1, fetch_full_page=False)
+
+    assert result["results"][0]["title"] == "Result A"
+    assert result["results"][0]["url"] == "https://example.com/a"
+    assert "first highlight" in result["results"][0]["content"]
+    assert "second highlight" in result["results"][0]["content"]
+    assert result["results"][0]["raw_content"] == result["results"][0]["content"]
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_falls_back_to_summary_when_no_highlights(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response(
+        [
+            SimpleNamespace(
+                title="Result B",
+                url="https://example.com/b",
+                text="full body text",
+                highlights=[],
+                summary="A concise summary.",
+            )
+        ]
+    )
+    mock_exa_cls.return_value = client
+
+    result = exa_search("test query", max_results=1, fetch_full_page=False)
+
+    assert result["results"][0]["content"] == "A concise summary."
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_falls_back_to_text_when_no_highlights_or_summary(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response(
+        [
+            SimpleNamespace(
+                title="Result C",
+                url="https://example.com/c",
+                text="just the body",
+                highlights=None,
+                summary=None,
+            )
+        ]
+    )
+    mock_exa_cls.return_value = client
+
+    result = exa_search("test query", max_results=1, fetch_full_page=False)
+
+    assert result["results"][0]["content"] == "just the body"
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_fetch_full_page_returns_text_as_raw_content(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response(
+        [
+            SimpleNamespace(
+                title="Result D",
+                url="https://example.com/d",
+                text="the full page text",
+                highlights=["a snippet"],
+                summary=None,
+            )
+        ]
+    )
+    mock_exa_cls.return_value = client
+
+    result = exa_search("test query", max_results=1, fetch_full_page=True)
+
+    assert result["results"][0]["content"] == "a snippet"
+    assert result["results"][0]["raw_content"] == "the full page text"
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_skips_results_missing_required_fields(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response(
+        [
+            SimpleNamespace(
+                title="No URL",
+                url="",
+                text="body",
+                highlights=["snippet"],
+                summary=None,
+            ),
+            SimpleNamespace(
+                title="Valid",
+                url="https://example.com/ok",
+                text="body",
+                highlights=["snippet"],
+                summary=None,
+            ),
+        ]
+    )
+    mock_exa_cls.return_value = client
+
+    result = exa_search("test query", max_results=2)
+
+    assert len(result["results"]) == 1
+    assert result["results"][0]["url"] == "https://example.com/ok"
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_sets_integration_header(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response([])
+    mock_exa_cls.return_value = client
+
+    exa_search("test query")
+
+    assert client.headers.get("x-exa-integration") == "local-deep-researcher"
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_passes_api_key_from_env(mock_exa_cls):
+    os.environ["EXA_API_KEY"] = "test-key-123"
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response([])
+    mock_exa_cls.return_value = client
+
+    exa_search("test query")
+
+    mock_exa_cls.assert_called_once_with(api_key="test-key-123")
+
+
+@patch("ollama_deep_researcher.utils.Exa")
+def test_exa_search_forwards_max_results_and_type(mock_exa_cls):
+    client = MagicMock()
+    client.headers = {}
+    client.search_and_contents.return_value = _make_response([])
+    mock_exa_cls.return_value = client
+
+    exa_search("a query", max_results=7)
+
+    _, kwargs = client.search_and_contents.call_args
+    assert kwargs["num_results"] == 7
+    assert kwargs["type"] == "auto"
+    assert "highlights" in kwargs["contents"]


### PR DESCRIPTION
## Summary

Adds [Exa](https://exa.ai/) as an additional search provider option alongside DuckDuckGo, Tavily, Perplexity, and SearXNG.

- New `exa_search()` in `utils.py` using the `exa-py` SDK's `search_and_contents` (type=`auto`)
- Returns the same `{title, url, content, raw_content}` shape the other providers use, so it plugs straight into `deduplicate_and_format_sources`
- Requests both `highlights` and `text` so the snippet builder can cascade `highlights -> summary -> text` when one isn't returned
- `fetch_full_page=True` returns the full page text via Exa's content endpoint instead of a separate HTTP fetch
- Added `"exa"` to `SearchAPI` enum and `search_api` Literal, wired it into `graph.py` dispatch
- Added `EXA_API_KEY` to `.env.example` and `exa-py>=2.0.0` to `pyproject.toml`
- Added unit tests under `tests/` (no test directory existed previously)

## Usage

```bash
# .env
SEARCH_API=exa
EXA_API_KEY=your-exa-key
```

```python
from ollama_deep_researcher.utils import exa_search

results = exa_search("recent advances in retrieval augmented generation", max_results=3)
# {"results": [{"title": ..., "url": ..., "content": ..., "raw_content": ...}, ...]}
```

## Files changed

- `src/ollama_deep_researcher/utils.py` — added `exa_search` function
- `src/ollama_deep_researcher/configuration.py` — added `EXA` to `SearchAPI` enum and the Literal
- `src/ollama_deep_researcher/graph.py` — added `exa` branch in the search dispatch
- `.env.example` — added `EXA_API_KEY`
- `pyproject.toml` — added `exa-py>=2.0.0`
- `README.md` — mentions Exa as a supported provider
- `tests/__init__.py`, `tests/test_exa_search.py` — new unit tests

## Test plan

- [x] `pytest tests/` passes locally (8 tests)
- [x] Tests cover: highlight/summary/text snippet fallback, `fetch_full_page` raw_content, skipping incomplete results, `x-exa-integration` header, `EXA_API_KEY` plumbing, kwargs forwarding
- [x] All tests use `unittest.mock.patch` against `ollama_deep_researcher.utils.Exa` (no live API calls)
- [x] Imports of `exa_search`, `graph`, and `SearchAPI.EXA` succeed
- [ ] End-to-end run via LangGraph Studio with a live `EXA_API_KEY` (left for maintainer review)