### PR TITLE
feat: add fastCRW search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Which search service to use, either 'duckduckgo', 'tavily', 'perplexity', Searxng
+# Which search service to use, either 'duckduckgo', 'tavily', 'perplexity', 'searxng', 'crw'
 SEARCH_API='duckduckgo'
 # For Searxng search, defaults to http://localhost:8888
 SEARXNG_URL=
@@ -6,6 +6,10 @@ SEARXNG_URL=
 # Web Search API Keys (choose one or both)
 TAVILY_API_KEY=tvly-xxxxx      # Get your key at https://tavily.com
 PERPLEXITY_API_KEY=pplx-xxxxx  # Get your key at https://www.perplexity.ai
+
+# For fastCRW search (Firecrawl-compatible web scraper; single binary; self-host or cloud)
+CRW_API_KEY=                   # Get your key at https://fastcrw.com (optional for self-hosted)
+CRW_BASE_URL=                  # Override base URL for self-host, defaults to https://fastcrw.com/api
 
 # LLM Configuration
 LLM_PROVIDER=lmstudio          # Options: ollama, lmstudio

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ LMSTUDIO_BASE_URL=http://localhost:1234/v1
 
 ### Selecting search tool
 
-By default, it will use [DuckDuckGo](https://duckduckgo.com/) for web search, which does not require an API key. But you can also use [SearXNG](https://docs.searxng.org/), [Tavily](https://tavily.com/) or [Perplexity](https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api) by adding their API keys to the environment file. Optionally, update the `.env` file with the following search tool configuration and API keys. If set, these values will take precedence over the defaults set in the `Configuration` class in `configuration.py`. 
+By default, it will use [DuckDuckGo](https://duckduckgo.com/) for web search, which does not require an API key. But you can also use [SearXNG](https://docs.searxng.org/), [Tavily](https://tavily.com/), [Perplexity](https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api) or [fastCRW](https://fastcrw.com/) by adding their API keys to the environment file. fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or cloud) whose search endpoint is SearXNG-backed with reranking and multi-round retrieval. Optionally, update the `.env` file with the following search tool configuration and API keys. If set, these values will take precedence over the defaults set in the `Configuration` class in `configuration.py`. 
 ```shell
 SEARCH_API=xxx # the search API to use, such as `duckduckgo` (default)
 TAVILY_API_KEY=xxx # the tavily API key to use
 PERPLEXITY_API_KEY=xxx # the perplexity API key to use
+CRW_API_KEY=xxx # the fastCRW API key to use (optional for self-hosted instances)
+CRW_BASE_URL=xxx # override the fastCRW base URL for self-host, defaults to `https://fastcrw.com/api`
 MAX_WEB_RESEARCH_LOOPS=xxx # the maximum number of research loop steps, defaults to `3`
 FETCH_FULL_PAGE=xxx # fetch the full page content (with `duckduckgo`), defaults to `false`
 ```

--- a/src/ollama_deep_researcher/configuration.py
+++ b/src/ollama_deep_researcher/configuration.py
@@ -11,6 +11,7 @@ class SearchAPI(Enum):
     TAVILY = "tavily"
     DUCKDUCKGO = "duckduckgo"
     SEARXNG = "searxng"
+    CRW = "crw"
 
 
 class Configuration(BaseModel):
@@ -31,8 +32,12 @@ class Configuration(BaseModel):
         title="LLM Provider",
         description="Provider for the LLM (Ollama or LMStudio)",
     )
-    search_api: Literal["perplexity", "tavily", "duckduckgo", "searxng"] = Field(
-        default="duckduckgo", title="Search API", description="Web search API to use"
+    search_api: Literal["perplexity", "tavily", "duckduckgo", "searxng", "crw"] = (
+        Field(
+            default="duckduckgo",
+            title="Search API",
+            description="Web search API to use",
+        )
     )
     fetch_full_page: bool = Field(
         default=True,

--- a/src/ollama_deep_researcher/graph.py
+++ b/src/ollama_deep_researcher/graph.py
@@ -17,6 +17,7 @@ from ollama_deep_researcher.utils import (
     perplexity_search,
     duckduckgo_search,
     searxng_search,
+    crw_search,
     strip_thinking_tokens,
     get_config_value,
 )
@@ -193,7 +194,7 @@ def web_research(state: SummaryState, config: RunnableConfig):
     """LangGraph node that performs web research using the generated search query.
 
     Executes a web search using the configured search API (tavily, perplexity,
-    duckduckgo, or searxng) and formats the results for further processing.
+    duckduckgo, searxng, or crw) and formats the results for further processing.
 
     Args:
         state: Current graph state containing the search query and research loop count
@@ -243,6 +244,17 @@ def web_research(state: SummaryState, config: RunnableConfig):
         )
     elif search_api == "searxng":
         search_results = searxng_search(
+            state.search_query,
+            max_results=3,
+            fetch_full_page=configurable.fetch_full_page,
+        )
+        search_str = deduplicate_and_format_sources(
+            search_results,
+            max_tokens_per_source=MAX_TOKENS_PER_SOURCE,
+            fetch_full_page=configurable.fetch_full_page,
+        )
+    elif search_api == "crw":
+        search_results = crw_search(
             state.search_query,
             max_results=3,
             fetch_full_page=configurable.fetch_full_page,

--- a/src/ollama_deep_researcher/utils.py
+++ b/src/ollama_deep_researcher/utils.py
@@ -275,6 +275,81 @@ def searxng_search(
 
 
 @traceable
+def crw_search(
+    query: str, max_results: int = 3, fetch_full_page: bool = False
+) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Search the web using fastCRW and return formatted results.
+
+    fastCRW is a Firecrawl-compatible web data engine (single binary; self-host or
+    cloud). Its search endpoint is SearXNG-backed with reranking and multi-round
+    retrieval, making it a managed upgrade from the raw SearXNG path. The base URL
+    is read from the CRW_BASE_URL environment variable or defaults to the managed
+    cloud at https://fastcrw.com/api, and the API key is read from CRW_API_KEY
+    (optional for self-hosted instances without auth).
+
+    Args:
+        query (str): The search query to execute
+        max_results (int, optional): Maximum number of results to return. Defaults to 3.
+        fetch_full_page (bool, optional): Whether to fetch full page content from result URLs.
+                                         Defaults to False.
+
+    Returns:
+        Dict[str, List[Dict[str, Any]]]: Search response containing:
+            - results (list): List of search result dictionaries, each containing:
+                - title (str): Title of the search result
+                - url (str): URL of the search result
+                - content (str): Snippet/summary of the content
+                - raw_content (str or None): Full page content if fetch_full_page is True,
+                                           otherwise same as content
+    """
+    base_url = os.environ.get("CRW_BASE_URL", "https://fastcrw.com/api").rstrip("/")
+    api_key = os.environ.get("CRW_API_KEY")
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    response = requests.post(
+        f"{base_url}/v1/search",
+        headers=headers,
+        json={"query": query, "limit": max_results},
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    # fastCRW uses a {success, error, data} envelope (Firecrawl-compatible)
+    if not data.get("success", True):
+        print(f"Error in fastCRW search: {data.get('error')}")
+        return {"results": []}
+
+    results = []
+    for r in data.get("data", []):
+        url = r.get("url")
+        title = r.get("title")
+        content = r.get("description")
+
+        if not all([url, title, content]):
+            print(f"Warning: Incomplete result from fastCRW: {r}")
+            continue
+
+        # fastCRW can return markdown inline; otherwise fetch the page if requested
+        raw_content = content
+        if fetch_full_page:
+            raw_content = r.get("markdown") or fetch_raw_content(url)
+
+        # Add result to list
+        result = {
+            "title": title,
+            "url": url,
+            "content": content,
+            "raw_content": raw_content,
+        }
+        results.append(result)
+    return {"results": results}
+
+
+@traceable
 def tavily_search(
     query: str, fetch_full_page: bool = True, max_results: int = 3
 ) -> Dict[str, List[Dict[str, Any]]]:

--- a/tests/test_crw_search.py
+++ b/tests/test_crw_search.py
@@ -1,0 +1,118 @@
+"""Tests for the fastCRW search provider in ollama_deep_researcher.utils.
+
+These tests mock the HTTP layer so no network access is required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from ollama_deep_researcher.utils import crw_search
+
+
+def _make_response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+@patch("ollama_deep_researcher.utils.requests.post")
+def test_crw_search_parses_results(mock_post):
+    mock_post.return_value = _make_response(
+        {
+            "success": True,
+            "data": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "description": "An example description",
+                }
+            ],
+        }
+    )
+
+    results = crw_search("python", max_results=3)
+
+    assert results == {
+        "results": [
+            {
+                "title": "Example",
+                "url": "https://example.com",
+                "content": "An example description",
+                "raw_content": "An example description",
+            }
+        ]
+    }
+
+    # Default cloud endpoint and limit are forwarded to the API
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://fastcrw.com/api/v1/search"
+    assert kwargs["json"] == {"query": "python", "limit": 3}
+
+
+@patch.dict(
+    "os.environ",
+    {"CRW_API_KEY": "test-key", "CRW_BASE_URL": "http://localhost:3000/"},
+    clear=False,
+)
+@patch("ollama_deep_researcher.utils.requests.post")
+def test_crw_search_uses_env_overrides(mock_post):
+    mock_post.return_value = _make_response({"success": True, "data": []})
+
+    crw_search("python")
+
+    args, kwargs = mock_post.call_args
+    # Self-host base URL override is honored and trailing slash is stripped
+    assert args[0] == "http://localhost:3000/v1/search"
+    assert kwargs["headers"]["Authorization"] == "Bearer test-key"
+
+
+@patch("ollama_deep_researcher.utils.requests.post")
+def test_crw_search_prefers_inline_markdown(mock_post):
+    mock_post.return_value = _make_response(
+        {
+            "success": True,
+            "data": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "description": "An example description",
+                    "markdown": "# Full markdown content",
+                }
+            ],
+        }
+    )
+
+    results = crw_search("python", fetch_full_page=True)
+
+    assert results["results"][0]["raw_content"] == "# Full markdown content"
+
+
+@patch("ollama_deep_researcher.utils.requests.post")
+def test_crw_search_handles_error_envelope(mock_post):
+    mock_post.return_value = _make_response(
+        {"success": False, "error": "rate limited"}
+    )
+
+    assert crw_search("python") == {"results": []}
+
+
+@patch("ollama_deep_researcher.utils.requests.post")
+def test_crw_search_skips_incomplete_results(mock_post):
+    mock_post.return_value = _make_response(
+        {
+            "success": True,
+            "data": [
+                {"title": "No URL", "description": "missing url"},
+                {
+                    "title": "Complete",
+                    "url": "https://example.com",
+                    "description": "ok",
+                },
+            ],
+        }
+    )
+
+    results = crw_search("python")
+
+    assert len(results["results"]) == 1
+    assert results["results"][0]["url"] == "https://example.com"


### PR DESCRIPTION
## What

Adds **`crw`** (fastCRW) to the `SearchAPI` options, alongside the existing `duckduckgo` / `tavily` / `perplexity` / `searxng`.

## Why

[fastCRW](https://fastcrw.com) is a fully open-source, self-hostable web scraping and search engine — a single **~8MB Rust binary**, **~6MB RAM** — designed to work where other scrapers fail.

### Why fastCRW for a local-first research stack

**1. Runs 100% locally and actually reaches JS-heavy / protected sites.**
Anti-bot handling, stealth mode, BYO-proxy with rotation, and JS (SPA) rendering all ship in the open core (AGPL). Competing scrapers gate their stealth engine behind cloud-only flags; their self-hosted builds silently fall back to plain fetch and cannot pass Cloudflare JS challenges or most protected sites. fastCRW's self-hosted build has no asterisks — one binary, no Redis, no worker fleet, no cloud dependency.

**2. Faster and higher quality — verified on an independent benchmark.**
On Firecrawl's own published benchmark dataset: truth-recall **63.74% vs 56.04%**, and median latency (p50) **~1.9s vs ~2.3s**. You get better answers faster, which compounds across the multi-round retrieval loops this project runs.

**3. Search is built on SearXNG — not a replacement for it.**
fastCRW is not an alternative to SearXNG; it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). So you get SearXNG's open-source breadth — the same foundation this project already supports — plus a measurable accuracy layer, all self-hostable (AGPL) with configurable engines.

The integration diff is tiny because fastCRW is Firecrawl-API-compatible, so it slots in as a new branch alongside the existing providers with no architectural changes.

## Changes (additive only)

- `src/ollama_deep_researcher/configuration.py`: `crw` added to the `SearchAPI` enum.
- `src/ollama_deep_researcher/graph.py`: a `crw` branch mirroring the existing tavily/searxng branches.
- `src/ollama_deep_researcher/utils.py`: a `crw_search()` helper returning the same normalized result shape as the others.
- `tests/test_crw_search.py`: unit tests with mocked HTTP (no network).
- `.env.example` + README note.

## Config

```bash
export SEARCH_API=crw
export CRW_API_KEY=...      # https://fastcrw.com/dashboard (free tier)
# or run fully local / self-hosted via a base-URL override
```

Happy to adjust anything to match your conventions — I maintain the integration and can provide free credits to evaluate.
